### PR TITLE
NEO reversion

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -38,7 +38,7 @@ public final class Constants {
   public static class DrivetrainConstants {
     // Applies to all teleop driving (exponential)
     public static final double kSpeedMult = 1; // Change this value to change driving speed [0..1]
-    public static final double kTurnMult = Math.sqrt(0.85); // Change this value to change turning speed [0..1]
+    public static final double kTurnMult = 0.7;
 
     // TurnToAngle
     public static final double kTurnPosTolerance = 0.75; // UNIT: degrees

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -36,9 +36,9 @@ public final class Constants {
   }
 
   public static class DrivetrainConstants {
-    // Applies to all teleop driving (exponential)
-    public static final double kSpeedMult = 1; // Change this value to change driving speed [0..1]
-    public static final double kTurnMult = 0.7;
+    // Applies to all teleop driving
+    public static final double kSpeedMult = 1; // Change driving speed [0..1] (squared before application)
+    public static final double kTurnMult = Math.sqrt(0.85); // Change turning speed [0..1] (squared before application)
 
     // TurnToAngle
     public static final double kTurnPosTolerance = 0.75; // UNIT: degrees

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -14,7 +14,7 @@ package frc.robot;
  */
 public final class Constants {
   public static class PhysConstants {
-    public static final double kDrivetrainGearbox = 1/8.45;
+    public static final double kDrivetrainGearbox = 1/7.31;
     public static final double kTiltGearbox = 1/35.0;
     public static final double kWheelGearbox = 1/3.0;
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -64,15 +64,15 @@ public class RobotContainer {
   }
 
   private void configureDriver() {
-    // final TurnToAngle cTurnToAngle = new TurnToAngle(0);
+    final TurnToAngle cTurnToAngle = new TurnToAngle(0);
 
     // D-pad will turn to the specified angle
-    // CommandScheduler.getInstance().getDefaultButtonLoop().bind(() -> {
-    //   if (TurnToAngle.m_enabled && OI.driver_cntlr.getPOV(0) != -1) {
-    //     cTurnToAngle.setHeading(OI.driver_cntlr.getPOV(0));
-    //     cTurnToAngle.schedule();
-    //   }
-    // });
+    CommandScheduler.getInstance().getDefaultButtonLoop().bind(() -> {
+      if (TurnToAngle.m_enabled && OI.driver_cntlr.getPOV(0) != -1) {
+        cTurnToAngle.setHeading(OI.driver_cntlr.getPOV(0));
+        cTurnToAngle.schedule();
+      }
+    });
 
     // Button 'A' (hold) will auto-balance
     final Command cBalance = Drivetrain.getInstance().getBalanceCommand();
@@ -90,7 +90,7 @@ public class RobotContainer {
 
     // Button 'Y' will toggle TurnToAngle
     OI.driver_cntlr.onTrue(btn.Y, () -> {
-      // cTurnToAngle.cancel();
+      cTurnToAngle.cancel();
       TurnToAngle.m_enabled ^= true;
     });
   }

--- a/src/main/java/frc/robot/autos/Bodies.java
+++ b/src/main/java/frc/robot/autos/Bodies.java
@@ -31,10 +31,10 @@ public class Bodies {
     switch (body) {
       case LONG_ESCAPE:
         // Drive backwards out of the community's longer side
-        // return new DriveDistance(-150);
+        return new DriveDistance(-150);
       case SHORT_ESCAPE:
         // Drive backwards out of the community's shorter side
-        // return new DriveDistance(-90);
+        return new DriveDistance(-90);
       case PICKUP_CONE:
         return PickupCone();
       case CENTER_CLIMB:
@@ -49,8 +49,8 @@ public class Bodies {
     Drivetrain sDrivetrain = Drivetrain.getInstance();
 
     return new SequentialCommandGroup(
-      // new DriveDistance(-165), // Move near cone
-      // new TurnToAngle(180),
+      new DriveDistance(-165), // Move near cone
+      new TurnToAngle(180),
       new InstantCommand(IntakeWheels::toCone),
 
       new ParallelCommandGroup(

--- a/src/main/java/frc/robot/autos/Endings.java
+++ b/src/main/java/frc/robot/autos/Endings.java
@@ -24,10 +24,10 @@ public class Endings {
     switch (end) {
       case TURN_AWAY:
         // Turn to face away from the drive station
-        // return new TurnToAngle(180);
+        return new TurnToAngle(180);
       case TURN_CLOSE:
         // Turn to face the drive station
-        // return new TurnToAngle(0);
+        return new TurnToAngle(0);
       default:
         return new InstantCommand();
     }

--- a/src/main/java/frc/robot/autos/Secondaries.java
+++ b/src/main/java/frc/robot/autos/Secondaries.java
@@ -27,8 +27,8 @@ public class Secondaries {
         // If picking up a cone, turn and return to the grid
         if (body == AutoSelector.Body.PICKUP_CONE) {
           return new SequentialCommandGroup(
-            // new TurnToAngle(0),
-            // new DriveDistance(205)
+            new TurnToAngle(0),
+            new DriveDistance(205)
           );
         };
 

--- a/src/main/java/frc/robot/commands/DriveDistance.java
+++ b/src/main/java/frc/robot/commands/DriveDistance.java
@@ -23,10 +23,9 @@ public class DriveDistance extends CommandBase {
 
   private final double distance; // UNIT: inches
 
-  private DriveDistance() {distance = 0;}
-  // public DriveDistance(double distance) {
-  //   this.distance = distance;
-  // }
+  public DriveDistance(double distance) {
+    this.distance = distance;
+  }
 
   /** Reset controller and encoders. */
   @Override

--- a/src/main/java/frc/robot/commands/TurnToAngle.java
+++ b/src/main/java/frc/robot/commands/TurnToAngle.java
@@ -27,10 +27,9 @@ public class TurnToAngle extends CommandBase {
   public static boolean m_enabled = false;
   private double heading;
 
-  private TurnToAngle() {}
-  // public TurnToAngle(double heading) {
-  //   this.heading = heading;
-  // }
+  public TurnToAngle(double heading) {
+    this.heading = heading;
+  }
 
   @Override
   public void initialize() {

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -88,13 +88,13 @@ public class Drivetrain extends SubsystemBase {
     setDefaultCommand(run(() -> {
       double triggers = OI.driver_cntlr.getTriggers();
       if (triggers == 0.0) {
-        // Arcade drive, input from left stick (higher priority)
+        // Arcade drive, input from left (front/back) and right (left/right) joysticks (lower priority)
         m_drive.arcadeDrive(
           -DrivetrainConstants.kSpeedMult * OI.driver_cntlr.getLeftY(),
-          DrivetrainConstants.kTurnMult * OI.driver_cntlr.getLeftX()
+          DrivetrainConstants.kTurnMult * OI.driver_cntlr.getRightX()
         );
       } else {
-        // Turn in place, input from triggers (lower priority)
+        // Turn in place, input from triggers (higher priority)
         turnInPlace(DrivetrainConstants.kTurnMult * DrivetrainConstants.kTurnMult * Math.copySign(triggers * triggers, triggers));
       }
     }));

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -2,7 +2,7 @@ package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.OI;
-// import frc.robot.Constants.PhysConstants;
+import frc.robot.Constants.PhysConstants;
 import frc.robot.Constants.DrivetrainConstants;
 import frc.robot.Constants.DeviceConstants;
 
@@ -11,7 +11,7 @@ import java.lang.Runnable;
 
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
-// import com.revrobotics.RelativeEncoder;
+import com.revrobotics.RelativeEncoder;
 
 import frc.robot.util.RobotDrive;
 import frc.robot.util.RobotDrive.WheelSpeeds;
@@ -51,22 +51,21 @@ public class Drivetrain extends SubsystemBase {
     return m_instance;
   }
 
-  // Initialize motors and differential drive
-  // private static final RelativeEncoder l_encoder;
-  // private static final RelativeEncoder r_encoder;
+  // Initialize motors, encoders, and differential drive
+  private static final RelativeEncoder l_encoder;
+  private static final RelativeEncoder r_encoder;
   private static final RobotDrive m_drive;
 
   static {
     @SuppressWarnings("resource")
-    // IMPORTANT: For use with brushed motors like CIM's - not for NEO's
     final CANSparkMax
-      fl_motor = new CANSparkMax(DeviceConstants.kFrontLeftID, MotorType.kBrushed),
-      bl_motor = new CANSparkMax(DeviceConstants.kBackLeftID, MotorType.kBrushed),
-      fr_motor = new CANSparkMax(DeviceConstants.kFrontRightID, MotorType.kBrushed),
-      br_motor = new CANSparkMax(DeviceConstants.kBackRightID, MotorType.kBrushed);
+      fl_motor = new CANSparkMax(DeviceConstants.kFrontLeftID, MotorType.kBrushless),
+      bl_motor = new CANSparkMax(DeviceConstants.kBackLeftID, MotorType.kBrushless),
+      fr_motor = new CANSparkMax(DeviceConstants.kFrontRightID, MotorType.kBrushless),
+      br_motor = new CANSparkMax(DeviceConstants.kBackRightID, MotorType.kBrushless);
 
-    // l_encoder = fl_motor.getEncoder();
-    // r_encoder = fr_motor.getEncoder();
+    l_encoder = fl_motor.getEncoder();
+    r_encoder = fr_motor.getEncoder();
 
     // IMPORTANT: Ensures motors have consistent output
     bl_motor.follow(fl_motor, false);
@@ -75,15 +74,15 @@ public class Drivetrain extends SubsystemBase {
   }
 
   private Drivetrain() {
-    // l_encoder.setPositionConversionFactor(PhysConstants.kWheelCircumference * PhysConstants.kDrivetrainGearbox); // UNIT: inches
-    // l_encoder.setVelocityConversionFactor(PhysConstants.kWheelCircumference * PhysConstants.kDrivetrainGearbox / 60); // UNIT: inches/s
-    // l_encoder.setMeasurementPeriod(20);
-    // l_encoder.setPosition(0);
+    l_encoder.setPositionConversionFactor(PhysConstants.kWheelCircumference * PhysConstants.kDrivetrainGearbox); // UNIT: inches
+    l_encoder.setVelocityConversionFactor(PhysConstants.kWheelCircumference * PhysConstants.kDrivetrainGearbox / 60); // UNIT: inches/s
+    l_encoder.setMeasurementPeriod(20);
+    l_encoder.setPosition(0);
 
-    // r_encoder.setPositionConversionFactor(PhysConstants.kWheelCircumference * PhysConstants.kDrivetrainGearbox); // UNIT: inches
-    // r_encoder.setVelocityConversionFactor(PhysConstants.kWheelCircumference * PhysConstants.kDrivetrainGearbox / 60); // UNIT: inches/s
-    // r_encoder.setMeasurementPeriod(20);
-    // r_encoder.setPosition(0);
+    r_encoder.setPositionConversionFactor(PhysConstants.kWheelCircumference * PhysConstants.kDrivetrainGearbox); // UNIT: inches
+    r_encoder.setVelocityConversionFactor(PhysConstants.kWheelCircumference * PhysConstants.kDrivetrainGearbox / 60); // UNIT: inches/s
+    r_encoder.setMeasurementPeriod(20);
+    r_encoder.setPosition(0);
 
     // Teleop drive: single joystick or turn in place with triggers
     setDefaultCommand(run(() -> {
@@ -92,7 +91,7 @@ public class Drivetrain extends SubsystemBase {
         // Arcade drive, input from left stick (higher priority)
         m_drive.arcadeDrive(
           -DrivetrainConstants.kSpeedMult * OI.driver_cntlr.getLeftY(),
-          DrivetrainConstants.kTurnMult * OI.driver_cntlr.getRightX()
+          DrivetrainConstants.kTurnMult * OI.driver_cntlr.getLeftX()
         );
       } else {
         // Turn in place, input from triggers (lower priority)
@@ -116,13 +115,12 @@ public class Drivetrain extends SubsystemBase {
 
   /** @return the average position of the drivetrain encoders */
   public double getPosition() {
-    // return (l_encoder.getPosition() - r_encoder.getPosition())/2;
-    return 0;
+    return (l_encoder.getPosition() - r_encoder.getPosition())/2;
   }
 
   public void resetEncoders() {
-    // l_encoder.setPosition(0);
-    // r_encoder.setPosition(0);
+    l_encoder.setPosition(0);
+    r_encoder.setPosition(0);
   }
 
   public static void stop() {

--- a/src/main/java/frc/robot/util/RobotDrive.java
+++ b/src/main/java/frc/robot/util/RobotDrive.java
@@ -38,9 +38,8 @@ public class RobotDrive extends MotorSafety {
    */
   public void drive(WheelSpeeds speeds) {
     speeds = MathUtil.desaturateWheelSpeeds(speeds);
-    // Inverted speeds to adjust for CIM inversion relative to NEOs
-    l_motor.set(-speeds.left);
-    r_motor.set(-speeds.right);
+    l_motor.set(speeds.left);
+    r_motor.set(speeds.right);
     feed();
   }
 


### PR DESCRIPTION
Revert drivetrain to Brushless NEOs with distance-based autons
Retains right stick arcade drive and teleop speed/turn multiplier documentation
Update drivetrain gearboxes from 8.46 to 7.31