### PR TITLE
Colorful game piece controls

### DIFF
--- a/src/main/java/frc/robot/shuffleboard/DriveTab.java
+++ b/src/main/java/frc/robot/shuffleboard/DriveTab.java
@@ -114,13 +114,13 @@ public class DriveTab implements ShuffleboardTabBase {
       .withPosition(13, 0)
       .withSize(4, 5);
 
-    layout_3.addBoolean("Inverted", IntakeWheels::isInverted)
+      .withWidget(BuiltInWidgets.kBooleanBox);
+    layout_3.addBoolean("Inverted", IntakeWheels::isCone)
+
+    layout_3.addBoolean("Intaking", () -> (Math.signum(sIntakeWheels.getSpeed()) == (IntakeWheels.isCone() ? -1.0 : 1.0)))
       .withWidget(BuiltInWidgets.kBooleanBox);
 
-    layout_3.addBoolean("Intaking", () -> (Math.signum(sIntakeWheels.getSpeed()) == (IntakeWheels.isInverted() ? -1.0 : 1.0)))
-      .withWidget(BuiltInWidgets.kBooleanBox);
-
-    layout_3.addBoolean("Shooting", () -> (Math.signum(sIntakeWheels.getSpeed()) == (IntakeWheels.isInverted() ? 1.0 : -1.0)))
+    layout_3.addBoolean("Shooting", () -> (Math.signum(sIntakeWheels.getSpeed()) == (IntakeWheels.isCone() ? 1.0 : -1.0)))
       .withWidget(BuiltInWidgets.kBooleanBox);
   }
 }

--- a/src/main/java/frc/robot/shuffleboard/DriveTab.java
+++ b/src/main/java/frc/robot/shuffleboard/DriveTab.java
@@ -114,8 +114,9 @@ public class DriveTab implements ShuffleboardTabBase {
       .withPosition(13, 0)
       .withSize(4, 5);
 
-      .withWidget(BuiltInWidgets.kBooleanBox);
     layout_3.addBoolean("Inverted", IntakeWheels::isCone)
+      .withWidget(BuiltInWidgets.kBooleanBox)
+      .withProperties(Map.of("color when true", 0xf5a800ff, "color when false", 0x31006fff));
 
     layout_3.addBoolean("Intaking", () -> (Math.signum(sIntakeWheels.getSpeed()) == (IntakeWheels.isCone() ? -1.0 : 1.0)))
       .withWidget(BuiltInWidgets.kBooleanBox);

--- a/src/main/java/frc/robot/shuffleboard/SimulationTab.java
+++ b/src/main/java/frc/robot/shuffleboard/SimulationTab.java
@@ -165,8 +165,9 @@ public class SimulationTab implements ShuffleboardTabBase {
       .withPosition(9, 0)
       .withSize(2, 8);
 
-      .withWidget(BuiltInWidgets.kBooleanBox);
     layout_4.addBoolean("Inverted", IntakeWheels::isCone)
+      .withWidget(BuiltInWidgets.kBooleanBox)
+      .withProperties(Map.of("color when true", 0xf5a800ff, "color when false", 0x31006fff));
 
     layout_4.addBoolean("Intaking", () -> (Math.signum(sIntakeWheels.getSpeed()) == (IntakeWheels.isCone() ? -1.0 : 1.0)))
       .withWidget(BuiltInWidgets.kBooleanBox);

--- a/src/main/java/frc/robot/shuffleboard/SimulationTab.java
+++ b/src/main/java/frc/robot/shuffleboard/SimulationTab.java
@@ -165,13 +165,13 @@ public class SimulationTab implements ShuffleboardTabBase {
       .withPosition(9, 0)
       .withSize(2, 8);
 
-    layout_4.addBoolean("Inverted", IntakeWheels::isInverted)
+      .withWidget(BuiltInWidgets.kBooleanBox);
+    layout_4.addBoolean("Inverted", IntakeWheels::isCone)
+
+    layout_4.addBoolean("Intaking", () -> (Math.signum(sIntakeWheels.getSpeed()) == (IntakeWheels.isCone() ? -1.0 : 1.0)))
       .withWidget(BuiltInWidgets.kBooleanBox);
 
-    layout_4.addBoolean("Intaking", () -> (Math.signum(sIntakeWheels.getSpeed()) == (IntakeWheels.isInverted() ? -1.0 : 1.0)))
-      .withWidget(BuiltInWidgets.kBooleanBox);
-
-    layout_4.addBoolean("Shooting", () -> (Math.signum(sIntakeWheels.getSpeed()) == (IntakeWheels.isInverted() ? 1.0 : -1.0)))
+    layout_4.addBoolean("Shooting", () -> (Math.signum(sIntakeWheels.getSpeed()) == (IntakeWheels.isCone() ? 1.0 : -1.0)))
       .withWidget(BuiltInWidgets.kBooleanBox);
 
     layout_4.add("Speed", new Sendable() {

--- a/src/main/java/frc/robot/shuffleboard/TestTab.java
+++ b/src/main/java/frc/robot/shuffleboard/TestTab.java
@@ -115,8 +115,8 @@ public class TestTab implements ShuffleboardTabBase {
       .withPosition(4, 4)
       .withSize(3, 4);
 
-    layout_3.addBoolean("Inverted", IntakeWheels::isInverted)
       .withWidget(BuiltInWidgets.kBooleanBox);
+    layout_3.addBoolean("Inverted", IntakeWheels::isCone)
 
     layout_3.add("Speed", new Sendable() {
       @Override

--- a/src/main/java/frc/robot/shuffleboard/TestTab.java
+++ b/src/main/java/frc/robot/shuffleboard/TestTab.java
@@ -115,8 +115,9 @@ public class TestTab implements ShuffleboardTabBase {
       .withPosition(4, 4)
       .withSize(3, 4);
 
-      .withWidget(BuiltInWidgets.kBooleanBox);
     layout_3.addBoolean("Inverted", IntakeWheels::isCone)
+      .withWidget(BuiltInWidgets.kBooleanBox)
+      .withProperties(Map.of("color when true", 0xf5a800ff, "color when false", 0x31006fff));
 
     layout_3.add("Speed", new Sendable() {
       @Override

--- a/src/main/java/frc/robot/subsystems/IntakeWheels.java
+++ b/src/main/java/frc/robot/subsystems/IntakeWheels.java
@@ -58,15 +58,16 @@ public class IntakeWheels extends SubsystemBase {
     m_inverted ^= true;
   }
 
-  public static boolean isInverted() {
+  /** @return {@code true} if the wheel speeds are inverted for cones */
+  public static boolean isCone() {
     return m_inverted;
   }
 
   /** Invert to cubes. */
-  public static void toCube() {if (isInverted()) {invert();}}
+  public static void toCube() {if (isCone()) {invert();}}
 
   /** Invert to cones. */
-  public static void toCone() {if (!isInverted()) {invert();}}
+  public static void toCone() {if (!isCone()) {invert();}}
 
   public static void stop() {
     m_motor.stopMotor();


### PR DESCRIPTION
Small style change to make inverting intake wheels for cones more clear
Small shuffleboard update so that game piece controls display respective colors (Riordan purple #31006f for cubes; Riordan gold #f5a800 for cones)